### PR TITLE
Bump boto3, requests, matplotlib, attrs and jsonpickle

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -140,11 +140,11 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.2.0"
+version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
@@ -248,10 +248,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = "*"
-version = "1.15.13"
+version = "1.16.34"
 
 [package.dependencies]
-botocore = ">=1.18.13,<1.19.0"
+botocore = ">=1.19.34,<1.20.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
@@ -261,7 +261,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = "*"
-version = "1.18.13"
+version = "1.19.34"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -269,7 +269,7 @@ python-dateutil = ">=2.1,<3.0.0"
 
 [package.dependencies.urllib3]
 python = "<3.4.0 || >=3.5.0"
-version = ">=1.20,<1.26"
+version = ">=1.25.4,<1.27"
 
 [[package]]
 category = "main"
@@ -1002,6 +1002,7 @@ six = "*"
 [[package]]
 category = "main"
 description = "Read metadata from Python packages"
+marker = "sys_platform != \"win32\" and python_version < \"3.8\" or python_version < \"3.8\" or python_version < \"3.7\" and python_version != \"3.4\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -1129,10 +1130,12 @@ description = "Python library for serializing any arbitrary object graph into JS
 name = "jsonpickle"
 optional = false
 python-versions = ">=2.7"
-version = "1.4.1"
+version = "1.4.2"
 
 [package.dependencies]
-importlib-metadata = "*"
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -1258,10 +1261,9 @@ description = "Python plotting package"
 name = "matplotlib"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.2"
+version = "3.3.3"
 
 [package.dependencies]
-certifi = ">=2020.06.20"
 cycler = ">=0.10"
 kiwisolver = ">=1.0.1"
 numpy = ">=1.15"
@@ -2226,13 +2228,13 @@ description = "Python HTTP for Humans."
 name = "requests"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.24.0"
+version = "2.25.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
@@ -3135,7 +3137,7 @@ spacy = ["spacy"]
 transformers = ["transformers"]
 
 [metadata]
-content-hash = "70a2b9f3034d3e87e9f739029340503efd48a512d913a34568c6cc6362963a53"
+content-hash = "97704a6e840115bf2ee22b3710455e071af68c4e7d7c094cd741ace4973761b8"
 python-versions = ">=3.6,<3.9"
 
 [metadata.files]
@@ -3194,8 +3196,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 aws-sam-translator = [
     {file = "aws-sam-translator-1.27.0.tar.gz", hash = "sha256:3258122f4cd671ba3dc141382dd0412c123db9f1317bed8b26e7229f63634454"},
@@ -3241,12 +3243,12 @@ boto = [
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.15.13-py2.py3-none-any.whl", hash = "sha256:f71ef9005bc49f92e822b3c24d651a9bc2b682a63acdcbbb2bc1d16da39c01ea"},
-    {file = "boto3-1.15.13.tar.gz", hash = "sha256:329178bd505b5d1dbb5eab25e9697c0e592c45548c895f451a91772d0e5a9329"},
+    {file = "boto3-1.16.34-py2.py3-none-any.whl", hash = "sha256:ddad9ada00eccae1fc2da28c69531ba202fead562994ddcd9a9a232e993cd8a2"},
+    {file = "boto3-1.16.34.tar.gz", hash = "sha256:616cde1e326949020da85a5bacaa7ad287e9f117d10ac9c5bfb9150a98dfe1a7"},
 ]
 botocore = [
-    {file = "botocore-1.18.13-py2.py3-none-any.whl", hash = "sha256:90e76683807896a28bbefd6e9bc3a2dc44ecd88fc6f6737fa0e3b20d5b7223ea"},
-    {file = "botocore-1.18.13.tar.gz", hash = "sha256:570609095c992732cf6158c3dd0a38619c77818fa700d6779b27277b34f98959"},
+    {file = "botocore-1.19.34-py2.py3-none-any.whl", hash = "sha256:49f5e56a7382a65ee0873371edcd91bdba8fc3f70abe102ebc1a0da2e6fbed06"},
+    {file = "botocore-1.19.34.tar.gz", hash = "sha256:4d81d92127ef646ae0f0ee84c9c220c92fa82312e765c29f8cb3b000fdbdd038"},
 ]
 cachetools = [
     {file = "cachetools-4.1.1-py3-none-any.whl", hash = "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98"},
@@ -3737,8 +3739,8 @@ jsonpatch = [
     {file = "jsonpatch-1.26.tar.gz", hash = "sha256:e45df18b0ab7df1925f20671bbc3f6bd0b4b556fb4b9c5d97684b0a7eac01744"},
 ]
 jsonpickle = [
-    {file = "jsonpickle-1.4.1-py2.py3-none-any.whl", hash = "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439"},
-    {file = "jsonpickle-1.4.1.tar.gz", hash = "sha256:e8d4b7cd0bd6826001a74377df1079a76ad8bae0f909282de2554164c837c8ba"},
+    {file = "jsonpickle-1.4.2-py2.py3-none-any.whl", hash = "sha256:2ac5863099864c63d7f0c367af5e512c94f3384977dd367f2eae5f2303f7b92c"},
+    {file = "jsonpickle-1.4.2.tar.gz", hash = "sha256:c9b99b28a9e6a3043ec993552db79f4389da11afcb1d0246d93c79f4b5e64062"},
 ]
 jsonpointer = [
     {file = "jsonpointer-2.0-py2.py3-none-any.whl", hash = "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"},
@@ -3767,16 +3769,19 @@ kiwisolver = [
     {file = "kiwisolver-1.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8"},
     {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"},
+    {file = "kiwisolver-1.2.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:be046da49fbc3aa9491cc7296db7e8d27bcf0c3d5d1a40259c10471b014e4e0c"},
     {file = "kiwisolver-1.2.0-cp36-none-win32.whl", hash = "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b"},
     {file = "kiwisolver-1.2.0-cp36-none-win_amd64.whl", hash = "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec"},
     {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec"},
+    {file = "kiwisolver-1.2.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:63f55f490b958b6299e4e5bdac66ac988c3d11b7fafa522800359075d4fa56d1"},
     {file = "kiwisolver-1.2.0-cp37-none-win32.whl", hash = "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c"},
     {file = "kiwisolver-1.2.0-cp37-none-win_amd64.whl", hash = "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1"},
     {file = "kiwisolver-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e"},
     {file = "kiwisolver-1.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657"},
+    {file = "kiwisolver-1.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:38d05c9ecb24eee1246391820ed7137ac42a50209c203c908154782fced90e44"},
     {file = "kiwisolver-1.2.0-cp38-none-win32.whl", hash = "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf"},
     {file = "kiwisolver-1.2.0-cp38-none-win_amd64.whl", hash = "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd"},
     {file = "kiwisolver-1.2.0.tar.gz", hash = "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f"},
@@ -3821,24 +3826,31 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib = [
-    {file = "matplotlib-3.3.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:27f9de4784ae6fb97679556c5542cf36c0751dccb4d6407f7c62517fa2078868"},
-    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:06866c138d81a593b535d037b2727bec9b0818cadfe6a81f6ec5715b8dd38a89"},
-    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5ccecb5f78b51b885f0028b646786889f49c54883e554fca41a2a05998063f23"},
-    {file = "matplotlib-3.3.2-cp36-cp36m-win32.whl", hash = "sha256:69cf76d673682140f46c6cb5e073332c1f1b2853c748dc1cb04f7d00023567f7"},
-    {file = "matplotlib-3.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:371518c769d84af8ec9b7dcb871ac44f7a67ef126dd3a15c88c25458e6b6d205"},
-    {file = "matplotlib-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:793e061054662aa27acaff9201cdd510a698541c6e8659eeceb31d66c16facc6"},
-    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16b241c3d17be786966495229714de37de04472da472277869b8d5b456a8df00"},
-    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3fb0409754b26f48045bacd6818e44e38ca9338089f8ba689e2f9344ff2847c7"},
-    {file = "matplotlib-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:548cfe81476dbac44db96e9c0b074b6fb333b4d1f12b1ae68dbed47e45166384"},
-    {file = "matplotlib-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f0268613073df055bcc6a490de733012f2cf4fe191c1adb74e41cec8add1a165"},
-    {file = "matplotlib-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:57be9e21073fc367237b03ecac0d9e4b8ddbe38e86ec4a316857d8d93ac9286c"},
-    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:be2f0ec62e0939a9dcfd3638c140c5a74fc929ee3fd1f31408ab8633db6e1523"},
-    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c5d0c2ae3e3ed4e9f46b7c03b40d443601012ffe8eb8dfbb2bd6b2d00509f797"},
-    {file = "matplotlib-3.3.2-cp38-cp38-win32.whl", hash = "sha256:a522de31e07ed7d6f954cda3fbd5ca4b8edbfc592a821a7b00291be6f843292e"},
-    {file = "matplotlib-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:8bc1d3284dee001f41ec98f59675f4d723683e1cc082830b440b5f081d8e0ade"},
-    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:799c421bc245a0749c1515b6dea6dc02db0a8c1f42446a0f03b3b82a60a900dc"},
-    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2f5eefc17dc2a71318d5a3496313be5c351c0731e8c4c6182c9ac3782cfc4076"},
-    {file = "matplotlib-3.3.2.tar.gz", hash = "sha256:3d2edbf59367f03cd9daf42939ca06383a7d7803e3993eb5ff1bee8e8a3fbb6b"},
+    {file = "matplotlib-3.3.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b2a5e1f637a92bb6f3526cc54cc8af0401112e81ce5cba6368a1b7908f9e18bc"},
+    {file = "matplotlib-3.3.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c586ac1d64432f92857c3cf4478cfb0ece1ae18b740593f8a39f2f0b27c7fda5"},
+    {file = "matplotlib-3.3.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9b03722c89a43a61d4d148acfc89ec5bb54cd0fd1539df25b10eb9c5fa6c393a"},
+    {file = "matplotlib-3.3.3-cp36-cp36m-win32.whl", hash = "sha256:2c2c5041608cb75c39cbd0ed05256f8a563e144234a524c59d091abbfa7a868f"},
+    {file = "matplotlib-3.3.3-cp36-cp36m-win_amd64.whl", hash = "sha256:c092fc4673260b1446b8578015321081d5db73b94533fe4bf9b69f44e948d174"},
+    {file = "matplotlib-3.3.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:27c9393fada62bd0ad7c730562a0fecbd3d5aaa8d9ed80ba7d3ebb8abc4f0453"},
+    {file = "matplotlib-3.3.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b8ba2a1dbb4660cb469fe8e1febb5119506059e675180c51396e1723ff9b79d9"},
+    {file = "matplotlib-3.3.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0caa687fce6174fef9b27d45f8cc57cbc572e04e98c81db8e628b12b563d59a2"},
+    {file = "matplotlib-3.3.3-cp37-cp37m-win32.whl", hash = "sha256:b7b09c61a91b742cb5460b72efd1fe26ef83c1c704f666e0af0df156b046aada"},
+    {file = "matplotlib-3.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6ffd2d80d76df2e5f9f0c0140b5af97e3b87dd29852dcdb103ec177d853ec06b"},
+    {file = "matplotlib-3.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5111d6d47a0f5b8f3e10af7a79d5e7eb7e73a22825391834734274c4f312a8a0"},
+    {file = "matplotlib-3.3.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a4fe54eab2c7129add75154823e6543b10261f9b65b2abe692d68743a4999f8c"},
+    {file = "matplotlib-3.3.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:83e6c895d93fdf93eeff1a21ee96778ba65ef258e5d284160f7c628fee40c38f"},
+    {file = "matplotlib-3.3.3-cp38-cp38-win32.whl", hash = "sha256:b26c472847911f5a7eb49e1c888c31c77c4ddf8023c1545e0e8e0367ba74fb15"},
+    {file = "matplotlib-3.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:09225edca87a79815822eb7d3be63a83ebd4d9d98d5aa3a15a94f4eee2435954"},
+    {file = "matplotlib-3.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eb6b6700ea454bb88333d98601e74928e06f9669c1ea231b4c4c666c1d7701b4"},
+    {file = "matplotlib-3.3.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2d31aff0c8184b05006ad756b9a4dc2a0805e94d28f3abc3187e881b6673b302"},
+    {file = "matplotlib-3.3.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d082f77b4ed876ae94a9373f0db96bf8768a7cca6c58fc3038f94e30ffde1880"},
+    {file = "matplotlib-3.3.3-cp39-cp39-win32.whl", hash = "sha256:e71cdd402047e657c1662073e9361106c6981e9621ab8c249388dfc3ec1de07b"},
+    {file = "matplotlib-3.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:756ee498b9ba35460e4cbbd73f09018e906daa8537fff61da5b5bf8d5e9de5c7"},
+    {file = "matplotlib-3.3.3-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7ad44f2c74c50567c694ee91c6fa16d67e7c8af6f22c656b80469ad927688457"},
+    {file = "matplotlib-3.3.3-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:3a4c3e9be63adf8e9b305aa58fb3ec40ecc61fd0f8fd3328ce55bc30e7a2aeb0"},
+    {file = "matplotlib-3.3.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:746897fbd72bd462b888c74ed35d812ca76006b04f717cd44698cdfc99aca70d"},
+    {file = "matplotlib-3.3.3-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:5ed3d3342698c2b1f3651f8ea6c099b0f196d16ee00e33dc3a6fee8cb01d530a"},
+    {file = "matplotlib-3.3.3.tar.gz", hash = "sha256:b1b60c6476c4cfe9e5cf8ab0d3127476fd3d5f05de0f343a452badaad0e4bdec"},
 ]
 mattermostwrapper = [
     {file = "mattermostwrapper-2.2.tar.gz", hash = "sha256:df17c4224b15c54d959addb12e83e3f1ada34bdb1fbed1048b7b9900d9cff53e"},
@@ -4127,8 +4139,11 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win32.whl", hash = "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
@@ -4386,6 +4401,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 questionary = [
@@ -4421,11 +4438,17 @@ regex = [
     {file = "regex-2020.9.27-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637"},
     {file = "regex-2020.9.27-cp38-cp38-win32.whl", hash = "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"},
     {file = "regex-2020.9.27-cp38-cp38-win_amd64.whl", hash = "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux1_i686.whl", hash = "sha256:84cada8effefe9a9f53f9b0d2ba9b7b6f5edf8d2155f9fdbe34616e06ececf81"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:816064fc915796ea1f26966163f6845de5af78923dfcecf6551e095f00983650"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:5d892a4f1c999834eaa3c32bc9e8b976c5825116cde553928c4c8e7e48ebda67"},
+    {file = "regex-2020.9.27-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c9443124c67b1515e4fe0bb0aa18df640965e1030f468a2a5dc2589b26d130ad"},
+    {file = "regex-2020.9.27-cp39-cp39-win32.whl", hash = "sha256:49f23ebd5ac073765ecbcf046edc10d63dcab2f4ae2bce160982cb30df0c0302"},
+    {file = "regex-2020.9.27-cp39-cp39-win_amd64.whl", hash = "sha256:3d20024a70b97b4f9546696cbf2fd30bae5f42229fbddf8661261b1eaff0deb7"},
     {file = "regex-2020.9.27.tar.gz", hash = "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d"},
 ]
 requests = [
-    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
-    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 requests-oauthlib = [
     {file = "requests-oauthlib-1.3.0.tar.gz", hash = "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"},
@@ -4448,7 +4471,7 @@ rocketchat-api = [
     {file = "rocketchat_API-1.9.1-py3-none-any.whl", hash = "sha256:8bc8afa216691ff9a67140e4dfa0116ee70f2b2d393d7819a32f6154951f1780"},
 ]
 rsa = [
-    {file = "rsa-4.6-py2.py3-none-any.whl", hash = "sha256:23778f5523461cf86ae075f9482a99317f362bca752ae57cb118044066f4026f"},
+    {file = "rsa-4.6-py3-none-any.whl", hash = "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"},
     {file = "rsa-4.6.tar.gz", hash = "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa"},
 ]
 "ruamel.yaml" = [
@@ -4463,20 +4486,29 @@ rsa = [
     {file = "ruamel.yaml.clib-0.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b"},
+    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988"},
+    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e"},
+    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99"},
+    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win32.whl", hash = "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b"},
+    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a"},
+    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5"},
+    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c"},
+    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win32.whl", hash = "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd"},
+    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb"},
     {file = "ruamel.yaml.clib-0.2.2.tar.gz", hash = "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"},
 ]
 s3transfer = [
@@ -4613,21 +4645,25 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.3.19-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:6547b27698b5b3bbfc5210233bd9523de849b2bb8a0329cd754c9308fc8a05ce"},
     {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:107d4af989831d7b091e382d192955679ec07a9209996bf8090f1f539ffc5804"},
     {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:eb1d71643e4154398b02e88a42fc8b29db8c44ce4134cf0f4474bfc5cb5d4dac"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:b6ff91356354b7ff3bd208adcf875056d3d886ed7cef90c571aef2ab8a554b12"},
     {file = "SQLAlchemy-1.3.19-cp35-cp35m-win32.whl", hash = "sha256:96f51489ac187f4bab588cf51f9ff2d40b6d170ac9a4270ffaed535c8404256b"},
     {file = "SQLAlchemy-1.3.19-cp35-cp35m-win_amd64.whl", hash = "sha256:618db68745682f64cedc96ca93707805d1f3a031747b5a0d8e150cfd5055ae4d"},
     {file = "SQLAlchemy-1.3.19-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:6557af9e0d23f46b8cd56f8af08eaac72d2e3c632ac8d5cf4e20215a8dca7cea"},
     {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8280f9dae4adb5889ce0bb3ec6a541bf05434db5f9ab7673078c00713d148365"},
     {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:b595e71c51657f9ee3235db8b53d0b57c09eee74dfb5b77edff0e46d2218dc02"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:51064ee7938526bab92acd049d41a1dc797422256086b39c08bafeffb9d304c6"},
     {file = "SQLAlchemy-1.3.19-cp36-cp36m-win32.whl", hash = "sha256:8afcb6f4064d234a43fea108859942d9795c4060ed0fbd9082b0f280181a15c1"},
     {file = "SQLAlchemy-1.3.19-cp36-cp36m-win_amd64.whl", hash = "sha256:e49947d583fe4d29af528677e4f0aa21f5e535ca2ae69c48270ebebd0d8843c0"},
     {file = "SQLAlchemy-1.3.19-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9e865835e36dfbb1873b65e722ea627c096c11b05f796831e3a9b542926e979e"},
     {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:276936d41111a501cf4a1a0543e25449108d87e9f8c94714f7660eaea89ae5fe"},
     {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c7adb1f69a80573698c2def5ead584138ca00fff4ad9785a4b0b2bf927ba308d"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:465c999ef30b1c7525f81330184121521418a67189053bcf585824d833c05b66"},
     {file = "SQLAlchemy-1.3.19-cp37-cp37m-win32.whl", hash = "sha256:aa0554495fe06172b550098909be8db79b5accdf6ffb59611900bea345df5eba"},
     {file = "SQLAlchemy-1.3.19-cp37-cp37m-win_amd64.whl", hash = "sha256:15c0bcd3c14f4086701c33a9e87e2c7ceb3bcb4a246cd88ec54a49cf2a5bd1a6"},
     {file = "SQLAlchemy-1.3.19-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fe7fe11019fc3e6600819775a7d55abc5446dda07e9795f5954fdbf8a49e1c37"},
     {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c898b3ebcc9eae7b36bd0b4bbbafce2d8076680f6868bcbacee2d39a7a9726a7"},
     {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:072766c3bd09294d716b2d114d46ffc5ccf8ea0b714a4e1c48253014b771c6bb"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:26c5ca9d09f0e21b8671a32f7d83caad5be1f6ff45eef5ec2f6fd0db85fc5dc0"},
     {file = "SQLAlchemy-1.3.19-cp38-cp38-win32.whl", hash = "sha256:b70bad2f1a5bd3460746c3fb3ab69e4e0eb5f59d977a23f9b66e5bdc74d97b86"},
     {file = "SQLAlchemy-1.3.19-cp38-cp38-win_amd64.whl", hash = "sha256:83469ad15262402b0e0974e612546bc0b05f379b5aa9072ebf66d0f8fef16bea"},
     {file = "SQLAlchemy-1.3.19.tar.gz", hash = "sha256:3bba2e9fbedb0511769780fe1d63007081008c5c2d7d715e91858c94dbaa260e"},
@@ -4784,19 +4820,28 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
     {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
     {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
     {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
     {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
     {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
     {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
     {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
     {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
+    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
+    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
 ]
 typeguard = [


### PR DESCRIPTION
Bumps [boto3](https://github.com/boto/boto3), [requests](https://github.com/psf/requests), [matplotlib](https://github.com/matplotlib/matplotlib), [attrs](https://github.com/python-attrs/attrs) and [jsonpickle](https://github.com/jsonpickle/jsonpickle).
Updates `boto3` from 1.15.13 to 1.16.34
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/boto/boto3/blob/develop/CHANGELOG.rst">boto3's changelog</a>.</em></p>
<blockquote>
<h1>1.16.34</h1>
<ul>
<li>api-change:<code>networkmanager</code>: [<code>botocore</code>] Update networkmanager client to latest version</li>
<li>api-change:<code>kendra</code>: [<code>botocore</code>] Update kendra client to latest version</li>
<li>api-change:<code>ec2</code>: [<code>botocore</code>] Update ec2 client to latest version</li>
</ul>
<h1>1.16.33</h1>
<ul>
<li>api-change:<code>globalaccelerator</code>: [<code>botocore</code>] Update globalaccelerator client to latest version</li>
<li>api-change:<code>ec2</code>: [<code>botocore</code>] Update ec2 client to latest version</li>
<li>api-change:<code>redshift</code>: [<code>botocore</code>] Update redshift client to latest version</li>
</ul>
<h1>1.16.32</h1>
<ul>
<li>api-change:<code>ecr</code>: [<code>botocore</code>] Update ecr client to latest version</li>
<li>api-change:<code>sagemaker</code>: [<code>botocore</code>] Update sagemaker client to latest version</li>
<li>api-change:<code>kendra</code>: [<code>botocore</code>] Update kendra client to latest version</li>
<li>api-change:<code>quicksight</code>: [<code>botocore</code>] Update quicksight client to latest version</li>
<li>api-change:<code>auditmanager</code>: [<code>botocore</code>] Update auditmanager client to latest version</li>
<li>api-change:<code>sagemaker-runtime</code>: [<code>botocore</code>] Update sagemaker-runtime client to latest version</li>
<li>api-change:<code>sagemaker-edge</code>: [<code>botocore</code>] Update sagemaker-edge client to latest version</li>
<li>api-change:<code>forecast</code>: [<code>botocore</code>] Update forecast client to latest version</li>
<li>api-change:<code>healthlake</code>: [<code>botocore</code>] Update healthlake client to latest version</li>
<li>api-change:<code>emr-containers</code>: [<code>botocore</code>] Update emr-containers client to latest version</li>
</ul>
<h1>1.16.31</h1>
<ul>
<li>api-change:<code>dms</code>: [<code>botocore</code>] Update dms client to latest version</li>
<li>api-change:<code>servicecatalog-appregistry</code>: [<code>botocore</code>] Update servicecatalog-appregistry client to latest version</li>
</ul>
<h1>1.16.30</h1>
<ul>
<li>api-change:<code>ssm</code>: [<code>botocore</code>] Update ssm client to latest version</li>
<li>api-change:<code>ec2</code>: [<code>botocore</code>] Update ec2 client to latest version</li>
<li>api-change:<code>workspaces</code>: [<code>botocore</code>] Update workspaces client to latest version</li>
<li>api-change:<code>license-manager</code>: [<code>botocore</code>] Update license-manager client to latest version</li>
<li>api-change:<code>lambda</code>: [<code>botocore</code>] Update lambda client to latest version</li>
<li>api-change:<code>ds</code>: [<code>botocore</code>] Update ds client to latest version</li>
<li>api-change:<code>kafka</code>: [<code>botocore</code>] Update kafka client to latest version</li>
<li>api-change:<code>medialive</code>: [<code>botocore</code>] Update medialive client to latest version</li>
<li>api-change:<code>rds</code>: [<code>botocore</code>] Update rds client to latest version</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/boto/boto3/commit/bd5db3390a8c57b7580747726881ab6479cdebd9"><code>bd5db33</code></a> Merge branch 'release-1.16.34'</li>
<li><a href="https://github.com/boto/boto3/commit/bd6279b84b91fb17d306c5390a2246432a5c6ed9"><code>bd6279b</code></a> Bumping version to 1.16.34</li>
<li><a href="https://github.com/boto/boto3/commit/92258f8971e72dcb22a9203c61e8f816d6c95eeb"><code>92258f8</code></a> Add changelog entries from botocore</li>
<li><a href="https://github.com/boto/boto3/commit/a142285242ac06baf3a3e063def34f37185524fe"><code>a142285</code></a> Merge branch 'release-1.16.33'</li>
<li><a href="https://github.com/boto/boto3/commit/36034dfa78f9545778f7e91edc35f840963e710a"><code>36034df</code></a> Merge branch 'release-1.16.33' into develop</li>
<li><a href="https://github.com/boto/boto3/commit/ef9984059a8a9fe634179297ed790427e0355355"><code>ef99840</code></a> Bumping version to 1.16.33</li>
<li><a href="https://github.com/boto/boto3/commit/453dcd3154be96e4208a713496ade8249208c1ad"><code>453dcd3</code></a> Add changelog entries from botocore</li>
<li><a href="https://github.com/boto/boto3/commit/44c5a0423aead63b54d8701da7bbab99d1e1f537"><code>44c5a04</code></a> Merge branch 'release-1.16.32'</li>
<li><a href="https://github.com/boto/boto3/commit/b5c979e66cf9fba360002017c2d6898a7fd6004e"><code>b5c979e</code></a> Merge branch 'release-1.16.32' into develop</li>
<li><a href="https://github.com/boto/boto3/commit/c22750a704211ffbb589f67061c9d9f04359b01d"><code>c22750a</code></a> Bumping version to 1.16.32</li>
<li>Additional commits viewable in <a href="https://github.com/boto/boto3/compare/1.15.13...1.16.34">compare view</a></li>
</ul>
</details>
<br />

Updates `requests` from 2.24.0 to 2.25.0
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/psf/requests/blob/master/HISTORY.md">requests's changelog</a>.</em></p>
<blockquote>
<h2>2.25.0 (2020-11-11)</h2>
<p><strong>Improvements</strong></p>
<ul>
<li>Added support for NETRC environment variable. (<a href="https://github-redirect.dependabot.com/psf/requests/issues/5643">#5643</a>)</li>
</ul>
<p><strong>Dependencies</strong></p>
<ul>
<li>Requests now supports urllib3 v1.26.</li>
</ul>
<p><strong>Deprecations</strong></p>
<ul>
<li>Requests v2.25.x will be the last release series with support for Python 3.5.</li>
<li>The <code>requests[security]</code> extra is officially deprecated and will be removed
in Requests v2.26.0.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/psf/requests/commit/03957eb1c2b9a1e5e6d61f5e930d7c5ed7cfe853"><code>03957eb</code></a> v2.25.0</li>
<li><a href="https://github.com/psf/requests/commit/320a10d142a7cbe224f0dcb1732484fff08cdd8e"><code>320a10d</code></a> Remove Pipfile/Pipfile.lock</li>
<li><a href="https://github.com/psf/requests/commit/9cd2d33489f95a97fdbb22a977ff4b7f51199702"><code>9cd2d33</code></a> Move CI to Github Actions</li>
<li><a href="https://github.com/psf/requests/commit/2f70990cd3fabf7b05cb9a69b3dab1a43bbf0096"><code>2f70990</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/psf/requests/issues/5643">#5643</a> from tarmath/netrc</li>
<li><a href="https://github.com/psf/requests/commit/ba543713d35067866d68b09f644042c0c021a8ba"><code>ba54371</code></a> Respect the NETRC environment variable</li>
<li><a href="https://github.com/psf/requests/commit/143150233162d609330941ec2aacde5ed4caa510"><code>1431502</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/psf/requests/issues/5614">#5614</a> from smstong/master</li>
<li><a href="https://github.com/psf/requests/commit/4840d4a3768d8eb4416875a921ad95ca9b86e789"><code>4840d4a</code></a> small typo corrected.</li>
<li><a href="https://github.com/psf/requests/commit/4f6c0187150af09d085c03096504934eb91c7a9e"><code>4f6c018</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/psf/requests/issues/5611">#5611</a> from psf/add-codescanning</li>
<li><a href="https://github.com/psf/requests/commit/d09c0e0f24486f66ceaa03b0631d7e23f385e7c2"><code>d09c0e0</code></a> Update codeql-analysis.yml</li>
<li><a href="https://github.com/psf/requests/commit/941ac53ba0251496b56b28c47ae48ea5a88e477a"><code>941ac53</code></a> Create codeql-analysis.yml</li>
<li>Additional commits viewable in <a href="https://github.com/psf/requests/compare/v2.24.0...v2.25.0">compare view</a></li>
</ul>
</details>
<br />

Updates `matplotlib` from 3.3.2 to 3.3.3
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/matplotlib/matplotlib/releases">matplotlib's releases</a>.</em></p>
<blockquote>
<h2>REL: v3.3.3</h2>
<p>This is the third bugfix release of the 3.3.x series.</p>
<p>This release contains several critical bug-fixes:</p>
<ul>
<li>Fix calls to <code>Axis.grid</code> with argument <code>visible=True</code>.</li>
<li>Fix fully masked <code>imshow</code>.</li>
<li>Fix inconsistent color mapping in scatter for 3D plots.</li>
<li>Fix notebook/nbAgg figures when used with ipywidgets in the same cell.</li>
<li>Fix notebook/nbAgg/WebAgg on older (e.g., Firefox ESR) browsers.</li>
<li>Fix pcolormesh with <code>datetime</code> coordinates.</li>
<li>Fix performance regression with <code>datetime</code>s.</li>
<li>Fix singular ticks with small log ranges.</li>
<li>Fix timers/animations on wx and notebook backends.</li>
<li>Remove certifi as a hard runtime dependency.</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/matplotlib/matplotlib/commit/5a4f1b675da3d17df2d77d03bceab331afcc21db"><code>5a4f1b6</code></a> REL: v3.3.3</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/1158688fd5e03af8ed2e8028bae106095204125a"><code>1158688</code></a> DOC: Update GitHub stats for 3.3.3.</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/3dc7152ea33dd6280f6042b7d2d2bd559a83e44e"><code>3dc7152</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18936">#18936</a> from QuLogic/auto-backport-of-pr-18929-on-v3.3.x</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/f679026f3979fa11f89adaae7d9808c75df4493d"><code>f679026</code></a> Backport PR <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18929">#18929</a>: FIX: make sure scalarmappable updates are handled correct...</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/fe81185019a13022c11d7fa3ec41f99456bf5319"><code>fe81185</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18928">#18928</a> from meeseeksmachine/auto-backport-of-pr-18842-on-v...</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/48f49dfbbe924ba4572d7cd54ed11be681abd82a"><code>48f49df</code></a> Backport PR <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18842">#18842</a>: Add CPython 3.9 wheels.</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/34bd55486c6985a1b00009350119063b97d7a98d"><code>34bd554</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18921">#18921</a> from meeseeksmachine/auto-backport-of-pr-18732-on-v...</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/7ff0fbc6eac747d0580b64a13bc542a5e0435fd6"><code>7ff0fbc</code></a> Backport PR <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18732">#18732</a>: Add a ponyfill for ResizeObserver on older browsers.</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/b65885c170257764a04ae0f2ff4c0a03caa93f2e"><code>b65885c</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/matplotlib/matplotlib/issues/18886">#18886</a> from jklymak/backport-18860</li>
<li><a href="https://github.com/matplotlib/matplotlib/commit/8988155bc5b97743da0e416a403c765b065398b8"><code>8988155</code></a> Backport: manual</li>
<li>Additional commits viewable in <a href="https://github.com/matplotlib/matplotlib/compare/v3.3.2...v3.3.3">compare view</a></li>
</ul>
</details>
<br />

Updates `attrs` from 20.2.0 to 20.3.0
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/python-attrs/attrs/releases">attrs's releases</a>.</em></p>
<blockquote>
<h2>20.3.0</h2>
<h2>Backward-incompatible Changes</h2>
<ul>
<li>
<p><code>attr.define()</code>, <code>attr.frozen()</code>, <code>attr.mutable()</code>, and <code>attr.field()</code> remain <strong>provisional</strong>.</p>
<p>This release does <strong>not</strong> change change anything about them and they are already used widely in production though.</p>
<p>If you wish to use them together with mypy, you can simply drop <a href="https://gist.github.com/hynek/1e3844d0c99e479e716169034b5fa963#file-attrs_ng_plugin-py">this plugin</a> into your project.</p>
<p>Feel free to provide feedback to them in the linked issue <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/668">#668</a>.</p>
<p>We will release the <code>attrs</code> namespace once we have the feeling that the APIs have properly settled. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/668">#668</a></p>
</li>
</ul>
<h2>Changes</h2>
<ul>
<li><code>attr.s()</code> now has a <em>field_transformer</em> hook that is called for all <code>Attribute</code>s and returns a (modified or updated) list of <code>Attribute</code> instances. <code>attr.asdict()</code> has a <em>value_serializer</em> hook that can change the way values are converted. Both hooks are meant to help with data (de-)serialization workflows. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/653">#653</a></li>
<li><code>kw_only=True</code> now works on Python 2. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/700">#700</a></li>
<li><code>raise from</code> now works on frozen classes on PyPy. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/703">#703</a>, <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/712">#712</a></li>
<li><code>attr.asdict()</code> and <code>attr.astuple()</code> now treat <code>frozenset</code>s like <code>set</code>s with regards to the <em>retain_collection_types</em> argument. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/704">#704</a></li>
<li>The type stubs for <code>attr.s()</code> and <code>attr.make_class()</code> are not missing the <em>collect_by_mro</em> argument anymore. <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/711">#711</a></li>
</ul>
</blockquote>
</details>
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst">attrs's changelog</a>.</em></p>
<blockquote>
<h2>20.3.0 (2020-11-05)</h2>
<p>Backward-incompatible Changes
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</p>
<ul>
<li>
<p><code>attr.define()</code>, <code>attr.frozen()</code>, <code>attr.mutable()</code>, and <code>attr.field()</code> remain <strong>provisional</strong>.</p>
<p>This release does <strong>not</strong> change change anything about them and they are already used widely in production though.</p>
<p>If you wish to use them together with mypy, you can simply drop <code>this plugin &lt;https://gist.github.com/hynek/1e3844d0c99e479e716169034b5fa963#file-attrs_ng_plugin-py&gt;</code>_ into your project.</p>
<p>Feel free to provide feedback to them in the linked issue <a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/668">#668</a>.</p>
<p>We will release the <code>attrs</code> namespace once we have the feeling that the APIs have properly settled.
<code>[#668](https://github.com/python-attrs/attrs/issues/668) &lt;https://github.com/python-attrs/attrs/issues/668&gt;</code>_</p>
</li>
</ul>
<p>Changes
^^^^^^^</p>
<ul>
<li><code>attr.s()</code> now has a <em>field_transformer</em> hook that is called for all <code>Attribute</code>\ s and returns a (modified or updated) list of <code>Attribute</code> instances.
<code>attr.asdict()</code> has a <em>value_serializer</em> hook that can change the way values are converted.
Both hooks are meant to help with data (de-)serialization workflows.
<code>[#653](https://github.com/python-attrs/attrs/issues/653) &lt;https://github.com/python-attrs/attrs/issues/653&gt;</code>_</li>
<li><code>kw_only=True</code> now works on Python 2.
<code>[#700](https://github.com/python-attrs/attrs/issues/700) &lt;https://github.com/python-attrs/attrs/issues/700&gt;</code>_</li>
<li><code>raise from</code> now works on frozen classes on PyPy.
<code>[#703](https://github.com/python-attrs/attrs/issues/703) &lt;https://github.com/python-attrs/attrs/issues/703&gt;</code><em>,
<code>[#712](https://github.com/python-attrs/attrs/issues/712) &lt;https://github.com/python-attrs/attrs/issues/712&gt;</code></em></li>
<li><code>attr.asdict()</code> and <code>attr.astuple()</code> now treat <code>frozenset</code>\ s like <code>set</code>\ s with regards to the <em>retain_collection_types</em> argument.
<code>[#704](https://github.com/python-attrs/attrs/issues/704) &lt;https://github.com/python-attrs/attrs/issues/704&gt;</code>_</li>
<li>The type stubs for <code>attr.s()</code> and <code>attr.make_class()</code> are not missing the <em>collect_by_mro</em> argument anymore.
<code>[#711](https://github.com/python-attrs/attrs/issues/711) &lt;https://github.com/python-attrs/attrs/issues/711&gt;</code>_</li>
</ul>
<hr />
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/python-attrs/attrs/commit/f3762ba07bf0cec8bebdaaeca2212ba1d662ff13"><code>f3762ba</code></a> Prepare 20.3.0</li>
<li><a href="https://github.com/python-attrs/attrs/commit/3d66e5727b93d3463feb0fd780ae739192e7c363"><code>3d66e57</code></a> Exclude GitHub issues from linkcheck to avoid rate limits</li>
<li><a href="https://github.com/python-attrs/attrs/commit/06d0f8eda63b3f08cb5d94fff9fddf4fe6695621"><code>06d0f8e</code></a> Add funding URLs to metadata</li>
<li><a href="https://github.com/python-attrs/attrs/commit/d23924f765d09f77e87a5c51c1685df0d721b469"><code>d23924f</code></a> Add provisional notice</li>
<li><a href="https://github.com/python-attrs/attrs/commit/cd2f886d6372dca288abf9d999b3e35dacd9ced6"><code>cd2f886</code></a> Use 'i' and 'k' to better distinguish variables in an example (<a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/713">#713</a>)</li>
<li><a href="https://github.com/python-attrs/attrs/commit/f2dabeae82c75abe174aafc7a726481ded929872"><code>f2dabea</code></a> Fix exception chaining on PyPy (<a href="https://github-redirect.dependabot.com/python-attrs/attrs/issues/712">#712</a>)</li>
<li><a href="https://github.com/python-attrs/attrs/commit/6b4a1f1ce65162afe54e7101b263859bf8b2177e"><code>6b4a1f1</code></a> Tighten up mypy configuration</li>
<li><a href="https://github.com/python-attrs/attrs/commit/9f7d11e415bc789c9cbab255cb9a5b8903c1b122"><code>9f7d11e</code></a> Add types to collect_by_mro annotations m(</li>
<li><a href="https://github.com/python-attrs/attrs/commit/7020c8b5b55adefc76cf369fb071b1a4b15554a9"><code>7020c8b</code></a> pre-commit autoupdate</li>
<li><a href="https://github.com/python-attrs/attrs/commit/56c73081c5d767e30f529ac4f15a6bdd43e23d9f"><code>56c7308</code></a> Add missing collect_by_mro to typing stubs</li>
<li>Additional commits viewable in <a href="https://github.com/python-attrs/attrs/compare/20.2.0...20.3.0">compare view</a></li>
</ul>
</details>
<br />

Updates `jsonpickle` from 1.4.1 to 1.4.2
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/jsonpickle/jsonpickle/blob/master/CHANGES.rst">jsonpickle's changelog</a>.</em></p>
<blockquote>
<h1>v1.4.2</h1>
<pre><code>* Use importlib.metadata from the stdlib on Python 3.8.  (+305) ([#303](https://github.com/jsonpickle/jsonpickle/issues/303))
* Micro-optimize type checks to use a `set` for lookups. (+327)
* Documentation improvements.
</code></pre>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/5b8d3ead870443a8a1355f597d31edcb2e41b970"><code>5b8d3ea</code></a> CHANGES: prepare for v1.4.2</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/175d934209b32c54ff0ae1d59aed584ae43a2f2e"><code>175d934</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/jsonpickle/jsonpickle/issues/327">#327</a> from laike9m/master</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/2c106302d4f3d4c768dc386a2fbc45957622bd04"><code>2c10630</code></a> Use set for checking types</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/86a9649dd455c14f1e504c9c08d0ed9cdd6549b7"><code>86a9649</code></a> maint: format code using black with &quot;make format&quot;</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/513cd0b8d7891459ed29b204b4793697bcab9fac"><code>513cd0b</code></a> tests: silence flake8 warnings</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/ff9bd85a108915dde45802ab1cf92fc01f8fecf0"><code>ff9bd85</code></a> Makefile: add &quot;format&quot; target</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/703efb7496787059ef8a7505fdf02dc74a4f915c"><code>703efb7</code></a> docs: add requirements for docs (for convenience)</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/47b086a001fc8d893c391fac475ca4956ac8550a"><code>47b086a</code></a> docs; call attention to the &quot;keys&quot; parameter</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/030fc73c42ce7d6625f760a0ef8c2963f4be3504"><code>030fc73</code></a> CHANGES: leverage rst.linker for PR and issue links</li>
<li><a href="https://github.com/jsonpickle/jsonpickle/commit/02f8ac0214ce95b2c111e787e30a8a2ff46ab1dd"><code>02f8ac0</code></a> docs: fix the tox links</li>
<li>Additional commits viewable in <a href="https://github.com/jsonpickle/jsonpickle/compare/v1.4.1...v1.4.2">compare view</a></li>
</ul>
</details>
<br />
